### PR TITLE
Fix SetGiftMonCaughtData CAUGHT_LEVEL

### DIFF
--- a/engine/pokemon/caught_data.asm
+++ b/engine/pokemon/caught_data.asm
@@ -241,6 +241,8 @@ SetGiftMonCaughtData:
 	adc h
 	sub l
 	ld h, a
+	xor a
+	ld [hli], a
 	ld a, GIFT_LOCATION
 	rrc b
 	or b

--- a/engine/pokemon/stats_screen.asm
+++ b/engine/pokemon/stats_screen.asm
@@ -838,8 +838,6 @@ StatsScreen_LoadGFX:
 	ld a, [wTempMonCaughtLevel]
 	and a
 	jr z, .unknown_level
-	cp GIFT_LOCATION
-	jr z, .unknown_level
 	cp CAUGHT_EGG_LEVEL
 	jr nz, .print
 	ld a, EGG_LEVEL ; egg hatch level


### PR DESCRIPTION
I reverted your previous change and applied the proper fix. After merge i'd recommend squashing the following commits into one commit with an appropriate title.

`Fix SetGiftMonCaughtData CAUGHT_LEVEL`

`Changed the traded Pokemon level in the fourth stat page to display ?s.`